### PR TITLE
Update rest-client to include rest-client/rest-client/pull/573

### DIFF
--- a/clickatellsend.gemspec
+++ b/clickatellsend.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rest-client", "~> 1.6"
+  spec.add_runtime_dependency "rest-client", "~> 2.0"
 end


### PR DESCRIPTION
Newer versions of Ruby (from 2.0.0-p594 onwards) have a different cipher list, and rest-client ~> 1.6 appears to break clickatellsend in Ruby 2.4 and up. This PR simply ups the version of rest-client from `~> 1.6` to `~> 2.0`. I ran tests as the readme guide recommends, but it looks like no tests have been added, so I won't post the output here.